### PR TITLE
Add option for linux ls style LIST response

### DIFF
--- a/ESP8266FtpServer.h
+++ b/ESP8266FtpServer.h
@@ -50,7 +50,7 @@
 class FtpServer
 {
 public:
-  void    begin(String uname, String pword);
+  void    begin(String uname, String pword, boolean _bUnixLst = false);
   void    handleFTP();
 
 private:
@@ -96,7 +96,7 @@ private:
            bytesTransfered;           //
   String   _FTP_USER;
   String   _FTP_PASS;
-
+  boolean  bUnixLst;
   
 
 };


### PR DESCRIPTION
Many FTP clients don’t actually seem to understand EPLF, so I added an
option to format LIST similarly to ls.
This works with Nautilus, Notepad++ and BBEdit for example.