### PR TITLE
Store fail when data connection closed to quickly

### DIFF
--- a/ESP8266FtpServer.cpp
+++ b/ESP8266FtpServer.cpp
@@ -596,7 +596,7 @@ boolean FtpServer::processCommand()
 		file = SPIFFS.open(path, "w");
       if( !file)
         client.println( "451 Can't open/create " +String(parameters) );
-      else if( ! dataConnect())
+      else if( ! dataConnect() && ! data.available())
       {
         client.println( "425 No data connection");
         file.close();


### PR DESCRIPTION
With FileZilla, little file file to upload because Filezilla close the connection after sending data before ESP be able to check the connection status of the connection so data are available but data connection is closed().
I think this can be attach to issue #26 